### PR TITLE
[Feat]/click outside of sidebar it should close

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -4,15 +4,18 @@ import Link from "next/link";
 import { langs } from "@/helper/Languages";
 import { tags } from "@/helper/tags";
 import { useRouter } from "next/router";
+import useClickOutside from "@/hooks/useClickOutside";
 
 export default function Navbar() {
   const router = useRouter();
 
   const [showSidebar, setShowSidebar] = useState(false);
 
+  const navbarRef = useClickOutside(() => setShowSidebar(false))
+  
   return (
     <>
-      <div className={`w-full ${showSidebar ? "sidebar-open" : ""}`}>
+      <div  className={`w-full ${showSidebar ? "sidebar-open" : ""}`} ref={navbarRef}>
         <div className="navbar sm:h-[90px] h-[75px] border-main_secondary border-b-2 w-full flex flex-grow items-center sm:p-8 py-2 px-3 justify-between bg-main_secondary_high shadow-md ">
           <div className="navbar_left logo">
             <Link href="/">
@@ -60,6 +63,7 @@ export default function Navbar() {
             )}
 
             <div
+              ref={navbarRef}
               className={`top-0 right-0 w-[230px] sm:w-[300px] bg-main_secondary_high border-main_secondary border-[2px] p-3 pt-3 text-main_secondary fixed h-full overflow-y-scroll  z-40 md:hidden ease-in-out duration-300 ${
                 showSidebar ? "translate-x-0 " : "translate-x-full"
               }`}

--- a/hooks/useClickOutside.ts
+++ b/hooks/useClickOutside.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+type ClickOutsideCallback = () => void;
+
+export default function useClickOutside (callbackFun: ClickOutsideCallback) {
+  
+  const domNodeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    
+    const handler = (event: MouseEvent) => {
+      if (domNodeRef.current && !domNodeRef.current.contains(event.target as Node)) {
+        callbackFun()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+
+    return () => {
+      document.removeEventListener("mousedown", handler)
+    }
+  }, [callbackFun]);
+
+  return domNodeRef;
+}


### PR DESCRIPTION
# PR Template 🚀

## 🐛 Fixed Issue

This PR Fixes #39, Which is nothing but whenever we click outside of sidebar it will close.

Fixes: #39 

## 🛠 Proposed Changes

I fallowed DRY principle and I added a  ```hooks``` folder inside that ```useClickOutside.js``` file is there it will help to fix this issue.

## 🖼️ Screenshots


https://github.com/anand346/findissues/assets/97227305/8bd5b7a4-f23b-457d-a2a2-9095bdd80da3



## Checklist ✅

- [x] All tests pass successfully.
- [x] Code adheres to the project's coding standards.
- [x] Documentation is updated to reflect the changes.
- [x] No sensitive information is inadvertently exposed.
- [x] Commit history is clear and concise.

## Reviewer Tasks 🕵️

Could you please focus on hooks folder.

## Additional Context ℹ️
Feel free to reach if you have any doubts.