### PR TITLE
Enhancement/update issue creation time

### DIFF
--- a/components/IssuesCard.js
+++ b/components/IssuesCard.js
@@ -10,7 +10,6 @@ export default function IssuesCard({ issue }) {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      console.log("setting time");
       setTimeFromNow(getTimeFromNow(issue.createdAt));
     }, 30000);
 

--- a/components/IssuesCard.js
+++ b/components/IssuesCard.js
@@ -1,6 +1,27 @@
+import { useHydration } from "@/hooks/useHydration";
+import { getTimeFromNow } from "@/utils/getTimeFromNow";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 export default function IssuesCard({ issue }) {
+  const [timeFromNow, setTimeFromNow] = useState(
+    getTimeFromNow(issue.createdAt),
+  );
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      console.log("setting time");
+      setTimeFromNow(getTimeFromNow(issue.createdAt));
+    }, 30000);
+
+    return () => clearInterval(intervalId);
+  });
+
+  // since we are updating a state based on time, we need to lookout for mismatches
+  // betwen server side and client side renders.
+  // this below hook will make the targeted component wait for rehydration before rendering
+  const hydrated = useHydration();
+
   return (
     <>
       <div className="issue_card mb-3 border-2 border-main_primary w-[100%] sm:w-[95%] rounded-sm flex flex-col justify-start items-start p-3 transition-all transform md:hover:scale-105">
@@ -63,10 +84,12 @@ export default function IssuesCard({ issue }) {
               </p>
             </div>
           </div>
-          <p className="issue_sec lg:text-[14px] sm:text-[12px] text-[12px] italic text-main_yellow">
-            <i className="fa fa-clock-o" aria-hidden="true"></i>{" "}
-            {issue.timeFromNow}
-          </p>
+          {/* wait for rehydration */}
+          {hydrated && (
+            <p className="issue_sec lg:text-[14px] sm:text-[12px] text-[12px] italic text-main_yellow">
+              <i className="fa fa-clock-o" aria-hidden="true"></i> {timeFromNow}
+            </p>
+          )}
         </div>
       </div>
     </>

--- a/hooks/useHydration.ts
+++ b/hooks/useHydration.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export function useHydration() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return hydrated;
+}

--- a/pages/search/[lang].js
+++ b/pages/search/[lang].js
@@ -1,16 +1,15 @@
-import { useRouter } from "next/router";
-import styles from "@/styles/LandingMain.module.css";
 import IssuesCard from "@/components/IssuesCard";
-import moment from "moment/moment";
-import { SkeletonCard } from "@/components/SkeletonCard";
-import { priority_langs } from "@/helper/priority_langs";
-import Image from "next/image";
-import error_404 from "../../public/404.svg";
-import { BsArrowRight } from "react-icons/bs";
-import Link from "next/link";
-import { tags } from "@/helper/tags";
-import { langs } from "@/helper/Languages";
 import SeoTags from "@/components/SeoTags";
+import { SkeletonCard } from "@/components/SkeletonCard";
+import { langs } from "@/helper/Languages";
+import { priority_langs } from "@/helper/priority_langs";
+import { tags } from "@/helper/tags";
+import styles from "@/styles/LandingMain.module.css";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { BsArrowRight } from "react-icons/bs";
+import error_404 from "../../public/404.svg";
 
 export default function Search({ allIssues, lang }) {
   const router = useRouter();
@@ -30,17 +29,15 @@ export default function Search({ allIssues, lang }) {
 
   return (
     <>
-
       <div
         className={`${styles.landing_main} p-3 md:p-8 issues_result overflow-auto w-[100%] md:w-[54%] landing_main h-full flex flex-col items-start justify-start`}
       >
-        
         {allIssues.length ? (
           <>
             <SeoTags
-                seoTitle={`FindIssues | Find Most Recent and Unassigned ${lang} Issues!`}
-                seoDescription={`FindIssues lets you find most recently created issues on GitHub that are not assigned to anyone according to ${lang} programming language`}
-                seoUrl={`https://www.findissues.me/search/${lang}`}
+              seoTitle={`FindIssues | Find Most Recent and Unassigned ${lang} Issues!`}
+              seoDescription={`FindIssues lets you find most recently created issues on GitHub that are not assigned to anyone according to ${lang} programming language`}
+              seoUrl={`https://www.findissues.me/search/${lang}`}
             />
             <p className="w-[250px] mb-4 font-semibold text-[16px] lg:text-[18px] text-main_primary">
               <span className="inline-block italic">All Unassigned Issues</span>{" "}
@@ -52,27 +49,27 @@ export default function Search({ allIssues, lang }) {
           </>
         ) : (
           <>
-          <SeoTags
-                seoTitle={`FindIssues - Page Not Found`}
-                seoDescription={`Page Not Found`}
-                seoUrl={`https://www.findissues.me`}
-          />
-          <div className="w-fit mx-auto">
-            <p className="w-full mb-4 font-semibold text-[16px] lg:text-4xl text-main_primary text-center">
-              Page Not Found
-            </p>
-            <Image
-              src={error_404}
-              alt="error 404"
-              className="w-3/5 mx-auto mt-8"
+            <SeoTags
+              seoTitle={`FindIssues - Page Not Found`}
+              seoDescription={`Page Not Found`}
+              seoUrl={`https://www.findissues.me`}
             />
-            <Link
-              href={"/"}
-              className="w-fit bg-transparent hover:bg-white rounded-full italic text-main_primary px-4 py-1 font-semibold flex items-center gap-2 text-sm mx-auto mt-8 border-y-4 "
-            >
-              Back to Home <BsArrowRight />
-            </Link>
-          </div>
+            <div className="w-fit mx-auto">
+              <p className="w-full mb-4 font-semibold text-[16px] lg:text-4xl text-main_primary text-center">
+                Page Not Found
+              </p>
+              <Image
+                src={error_404}
+                alt="error 404"
+                className="w-3/5 mx-auto mt-8"
+              />
+              <Link
+                href={"/"}
+                className="w-fit bg-transparent hover:bg-white rounded-full italic text-main_primary px-4 py-1 font-semibold flex items-center gap-2 text-sm mx-auto mt-8 border-y-4 "
+              >
+                Back to Home <BsArrowRight />
+              </Link>
+            </div>
           </>
         )}
       </div>
@@ -101,16 +98,6 @@ async function loadRepo(issueItems) {
   return repoObj;
 }
 
-function getTimeFromNow(created_at) {
-  var timestamp = created_at.split("T");
-  var date = timestamp[0];
-  var time = timestamp[1].split("Z")[0];
-  var finalTime = date + " " + time;
-
-  var finalTimeFromNow = moment.utc(finalTime, "YYYY-MM-DD HH:mm:ss").fromNow();
-  return finalTimeFromNow;
-}
-
 async function loadIssues(url, query_lang) {
   const issues_res = await fetch(url, {
     headers: {
@@ -132,7 +119,6 @@ async function loadIssues(url, query_lang) {
     mask = "language";
   }
   issueItems.forEach((issue) => {
-    var finalTimeFromNow = getTimeFromNow(issue.created_at);
     var lang = query_lang;
 
     var issueObj = {
@@ -141,7 +127,7 @@ async function loadIssues(url, query_lang) {
       issueUrl: issue.html_url,
       issueTitle: issue.title,
       repoTitle: repo_res[issue.id].full_name,
-      timeFromNow: finalTimeFromNow,
+      createdAt: issue.created_at,
       repo_forks: repo_res[issue.id].forks_count,
       repo_stars: repo_res[issue.id].stargazers_count,
       [mask]: query_lang,
@@ -188,7 +174,7 @@ export async function getStaticProps({ params }) {
   return {
     props: {
       allIssues: lang_issues,
-      lang: params.lang
+      lang: params.lang,
     },
     revalidate: 600,
   };

--- a/utils/getTimeFromNow.js
+++ b/utils/getTimeFromNow.js
@@ -1,0 +1,11 @@
+import moment from "moment/moment";
+
+export function getTimeFromNow(created_at) {
+  var timestamp = created_at.split("T");
+  var date = timestamp[0];
+  var time = timestamp[1].split("Z")[0];
+  var finalTime = date + " " + time;
+
+  var finalTimeFromNow = moment.utc(finalTime, "YYYY-MM-DD HH:mm:ss").fromNow();
+  return finalTimeFromNow;
+}

--- a/utils/getTimeFromNow.js
+++ b/utils/getTimeFromNow.js
@@ -1,11 +1,48 @@
 import moment from "moment/moment";
 
 export function getTimeFromNow(created_at) {
-  var timestamp = created_at.split("T");
-  var date = timestamp[0];
-  var time = timestamp[1].split("Z")[0];
-  var finalTime = date + " " + time;
+  const timeDifferenceInMilliseconds = Math.abs(
+    moment
+      .utc(created_at, "YYYY-MM-DD HH:mm:ss")
+      .diff(moment.now(), "milliseconds", true),
+  );
 
-  var finalTimeFromNow = moment.utc(finalTime, "YYYY-MM-DD HH:mm:ss").fromNow();
+  let finalTimePrefix = "a few";
+  let finalTimeUnit = "seconds";
+
+  const timeDifferenceInSeconds = Math.floor(
+    timeDifferenceInMilliseconds / 1000,
+  );
+  const timeDifferenceInMinutes = Math.floor(timeDifferenceInSeconds / 60);
+  const timeDifferenceInHours = Math.floor(timeDifferenceInMinutes / 60);
+  const timeDifferenceInDays = Math.floor(timeDifferenceInHours / 24);
+  const timeDifferenceInWeeks = Math.floor(timeDifferenceInDays / 7);
+  const timeDifferenceInMonths = Math.floor(timeDifferenceInDays / 30);
+  const timeDifferenceInYears = Math.floor(timeDifferenceInDays / 365);
+
+  if (timeDifferenceInYears >= 1) {
+    finalTimePrefix = timeDifferenceInYears;
+    finalTimeUnit = timeDifferenceInYears === 1 ? "year" : "years";
+  } else if (timeDifferenceInMonths >= 1) {
+    finalTimePrefix = timeDifferenceInMonths;
+    finalTimeUnit = timeDifferenceInMonths === 1 ? "month" : "months";
+  } else if (timeDifferenceInWeeks >= 1) {
+    finalTimePrefix = timeDifferenceInWeeks;
+    finalTimeUnit = timeDifferenceInWeeks === 1 ? "week" : "weeks";
+  } else if (timeDifferenceInDays >= 1) {
+    finalTimePrefix = timeDifferenceInDays;
+    finalTimeUnit = timeDifferenceInDays === 1 ? "day" : "days";
+  } else if (timeDifferenceInHours >= 1) {
+    finalTimePrefix = timeDifferenceInHours;
+    finalTimeUnit = timeDifferenceInHours === 1 ? "hour" : "hours";
+  } else if (timeDifferenceInMinutes >= 1) {
+    finalTimePrefix = timeDifferenceInMinutes;
+    finalTimeUnit = timeDifferenceInMinutes === 1 ? "minute" : "minutes";
+  } else if (timeDifferenceInSeconds > 10) {
+    finalTimePrefix = timeDifferenceInSeconds;
+  }
+
+  let finalTimeFromNow = `${finalTimePrefix} ${finalTimeUnit} ago`;
+
   return finalTimeFromNow;
 }


### PR DESCRIPTION
🐛 Fixed Issue https://github.com/anand346/findissues/issues/49
https://github.com/anand346/findissues/issues/49

🛠 Proposed Changes
In the issues card component we are introducing regular updating of time elapsed since issue creation. It's updated at an interval of 30 seconds.
screenshot.
The calculation logic for time elapsed since issue creation has been updated. The previous calculation was done through a utility function from moment.js which was inconsistent with github's calculation on the same. Now we have our own logic implemented for this.

📝 Notes for Reviewers
The interval of 30 seconds should be good enough for this use case. We can increase it to 60 seconds if we notice a hit on performance and need to reduce the amount of re-renders by half. But on local testing there was hardly any change in rendering performance.

The calculated time elapsed is still a little different from what github will display on their issue page. 
For example when it has been 56 minutes since issue creation, our code will show it accurately as "56 minutes ago" but github's issue page will show it as "1 hour ago".  Github is rounding it up.