### PR TITLE
fixes scroll indicator

### DIFF
--- a/styles/LeftSidebar.module.css
+++ b/styles/LeftSidebar.module.css
@@ -1,3 +1,7 @@
+.left_sidebar{
+  overflow-y: scroll;
+  scrollbar-color: #999 transparent;
+}
 .left_sidebar::-webkit-scrollbar {
   width: 0px;
 }


### PR DESCRIPTION
# PR Template 🚀

## 🐛 Fixed Issue

The left sidebar and main sections lack a visible sidebar, which sometimes gives the perception that no more tags, repositories, or content might be available. Adding a visible indicator helps users understand that they can scroll to find more content.

Issue #141 

## 🛠 Proposed Changes

Added a visible sidebar to the left sidebar.
Once the user starts scrolling, the scroll bar hides to maintain the theme and avoid clutter, aligning with the design aesthetics


## 🖼️ Screenshots
<img width="1023" alt="Screenshot 2024-08-05 at 9 06 46 AM" src="https://github.com/user-attachments/assets/fb764583-9eff-426e-8a22-decbd3c3a7fb">


## 📝 Notes for Reviewers

The sidebar's visibility serves as an initial cue for users. The scroll bar hides after scrolling starts to keep the interface clean and thematic.


## Checklist ✅

- [x] Starred this repo ⭐.
- [x] Code adheres to the project's coding standards 💻.
- [x] No sensitive information is inadvertently exposed 👀.
- [x] Commit history is clear and concise 📃.

## Reviewer Tasks 🕵️

Test the changes across various screen sizes and resolutions.


