### PR TITLE
chore: add Excalidraw, Grafana, and Sherlock to active repos list

### DIFF
--- a/_data/repos.js
+++ b/_data/repos.js
@@ -62,4 +62,7 @@ export const repos_list = [
     'https://github.com/hoppscotch/hoppscotch',
     'https://github.com/elastic/kibana',
     'https://github.com/darkreader/darkreader',
+    'https://github.com/excalidraw/excalidraw',      
+    'https://github.com/grafana/grafana',            
+    'https://github.com/sherlock-project/sherlock',  
 ]


### PR DESCRIPTION
## Summary
Added three active open-source repositories that meet the FindIssues project criteria for Hacktoberfest 2025:

- [Excalidraw](https://github.com/excalidraw/excalidraw)
- [Grafana](https://github.com/grafana/grafana)
- [Sherlock](https://github.com/sherlock-project/sherlock)

These repositories:
- Were updated within the last 3 days
- Have more than 50 stars
- Are accepting open source contributions

## Changes
- Updated `_data/repos.js` to include the above three repositories.
- Ensured formatting consistency and followed the existing array style.

## Notes
This contribution follows the repository’s [contributing guidelines](https://github.com/anandraaj24/findissues/blob/main/CONTRIBUTING.md) and Hacktoberfest participation rules.

Thanks for maintaining such a great beginner-friendly project! 🚀